### PR TITLE
Swapped out document.body.classList with ...className

### DIFF
--- a/src/helpers/bodyClassList.js
+++ b/src/helpers/bodyClassList.js
@@ -5,7 +5,7 @@ export function add (bodyClass) {
   bodyClass
     .split(' ')
     .map(refCount.add)
-    .forEach(className => document.body.classList.add(className));
+    .forEach(className => document.body.className += ' ' + className);
 }
 
 export function remove (bodyClass) {


### PR DESCRIPTION
Fixes IE9 error "Unable to get property 'add' of undefined or null reference"
